### PR TITLE
Fix compilation issue on ESP32S2

### DIFF
--- a/ESP32DMASPIMaster.h
+++ b/ESP32DMASPIMaster.h
@@ -22,6 +22,11 @@
     }
 #endif
 
+#if CONFIG_IDF_TARGET_ESP32S2
+    #define VSPI FSPI
+    #define VSPI_HOST FSPI_HOST
+#endif
+
 ARDUINO_ESP32_DMA_SPI_NAMESPACE_BEGIN
 
 class Master {

--- a/ESP32DMASPISlave.h
+++ b/ESP32DMASPISlave.h
@@ -22,6 +22,11 @@
     }
 #endif
 
+#if CONFIG_IDF_TARGET_ESP32S2
+    #define VSPI FSPI
+    #define VSPI_HOST FSPI_HOST
+#endif
+
 ARDUINO_ESP32_DMA_SPI_NAMESPACE_BEGIN
 
 void spi_slave_setup_done(spi_slave_transaction_t* trans);


### PR DESCRIPTION
ESP32S2 has renamed the SPI peripherals; it can't compile without renaming VSPI to FSPI.